### PR TITLE
Add 'nfm_reply' to WebhookInteractiveMessage type

### DIFF
--- a/packages/types/src/webhook/message.ts
+++ b/packages/types/src/webhook/message.ts
@@ -166,7 +166,7 @@ export interface WebhookInteractiveMessage extends WebhookMessageBase {
     /**
      * Type of interactive message
      */
-    type: 'button_reply' | 'list_reply'
+    type: 'button_reply' | 'list_reply' | 'nfm_reply'
     /**
      * Button reply message payload
      */
@@ -196,6 +196,23 @@ export interface WebhookInteractiveMessage extends WebhookMessageBase {
        * Description of the selected item
        */
       description: string
+    }
+    /**
+     * NFM reply message payload
+     */
+    nfm_reply?: {
+      /**
+       * The name of the flow
+       */
+      name: string
+      /**
+       * The body/content of the flow
+       */
+      body: string
+      /**
+       * JSON response from the flow
+       */
+      response_json: string
     }
   }
 }


### PR DESCRIPTION
This PR adds the 'nfm_reply' property to the `WebhookInteractiveMessage` type to support NFM replies.

- Added 'nfm_reply' to the `interactive` type, which includes:
  - `name`: Flow name
  - `body`: Flow body content
  - `response_json`: JSON response from the flow