### PR TITLE
fix(client): support recipient (BSUID) on 6 missing send methods

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -14,6 +14,12 @@
 - 🔄 Modern ESM package
 - ⚡ Lightweight and efficient
 
+> **Note (v25 / BSUID addressing):** every `send*Message` method accepts an
+> optional `recipient` (business-scoped user ID) as an alternative to `to` (the
+> phone number / phone number ID). Supply at least one; if both are supplied,
+> `to` takes precedence — matching the Cloud API. `recipient` is required when
+> the user has hidden their phone number behind a WhatsApp username.
+
 ## Installation
 
 ```bash
@@ -42,6 +48,15 @@ const responseWithPreview = await sendTextMessage({
   to: 'RECIPIENT_PHONE_NUMBER',
   text: 'Check out this link: https://example.com',
   previewUrl: true, // Enable link preview
+})
+
+// Send to a business-scoped user ID (BSUID) — for users who have hidden
+// their phone number behind a WhatsApp username
+const responseToBSUID = await sendTextMessage({
+  accessToken: 'YOUR_ACCESS_TOKEN',
+  from: 'YOUR_PHONE_NUMBER_ID',
+  recipient: 'US.13491208655302741918', // BSUID instead of phone number
+  text: 'Hello from WhatsApp Cloud API!',
 })
 ```
 
@@ -160,6 +175,40 @@ import {
 
 ## API Reference
 
+### Available send methods
+
+Every method below is exported from `@whatsapp-cloudapi/client` and accepts an
+optional `recipient` (BSUID) in place of `to` (phone number). The methods marked
+**✏️ documented below** have a full reference section in this README; the
+others share the same shape (`accessToken`, `from`, `to?`, `recipient?`, plus
+their type-specific fields) and are fully typed — refer to their JSDoc in your
+editor.
+
+| Method                             | Purpose                                                  |                 |
+| ---------------------------------- | -------------------------------------------------------- | --------------- |
+| `sendTextMessage`                  | Plain text message (with optional link preview)          | ✏️ documented   |
+| `sendImageMessage`                 | Image by `mediaId` or `link` (with optional caption)     | ✏️ documented   |
+| `sendAudioMessage`                 | Audio by `mediaId` or `link`                             |                 |
+| `sendVideoMessage`                 | Video by `mediaId` or `link` (with optional caption)     |                 |
+| `sendDocumentMessage`              | Document by `mediaId` or `link` (with optional filename) |                 |
+| `sendStickerMessage`               | Sticker by `mediaId` or `link`                           |                 |
+| `sendLocationMessage`              | Lat/long location pin (with optional name/address)       |                 |
+| `sendContactsMessage`              | One or more contact cards                                |                 |
+| `sendReactionMessage`              | Emoji reaction to a previous message                     |                 |
+| `sendTemplateMessage`              | Pre-approved message template with optional components   | (example above) |
+| `sendButtonsMessage`               | Interactive reply buttons (up to 3)                      | ✏️ documented   |
+| `sendListMessage`                  | Interactive list (up to 10 rows across sections)         | ✏️ documented   |
+| `sendCTAURLMessage`                | Interactive call-to-action URL button                    | ✏️ documented   |
+| `sendFlowMessage`                  | Interactive WhatsApp Flow                                | ✏️ documented   |
+| `sendCatalogMessage`               | Catalog interactive message                              |                 |
+| `sendProductMessage`               | Single product interactive message                       |                 |
+| `sendProductListMessage`           | Multi-product interactive list                           |                 |
+| `sendRequestContactInfoMessage`    | Interactive contact-info request                         |                 |
+| `sendCallPermissionRequestMessage` | Interactive call permission request                      |                 |
+
+Other exports: `markMessageRead`, `uploadMedia`, `getMediaUrl`, `downloadMedia`,
+`deleteMedia`, `blockUsers`, `unblockUsers`, `listBlockedUsers`.
+
 ### sendTextMessage
 
 Sends a text message to a WhatsApp user.
@@ -168,7 +217,8 @@ Sends a text message to a WhatsApp user.
 function sendTextMessage(params: {
   accessToken: string
   from: string
-  to: string
+  to?: string
+  recipient?: string
   text: string
   previewUrl?: boolean
   bizOpaqueCallbackData?: string
@@ -180,7 +230,8 @@ function sendTextMessage(params: {
 
 - `accessToken` (string) - Your WhatsApp Cloud API access token
 - `from` (string) - Your WhatsApp Phone Number ID
-- `to` (string) - Recipient's phone number with country code (e.g., "+16505551234")
+- `to` (string, optional) - Recipient's phone number with country code (e.g., "+16505551234"). At least one of `to` / `recipient` is required
+- `recipient` (string, optional) - Recipient's business-scoped user ID (BSUID). At least one of `to` / `recipient` is required; `to` takes precedence when both are set
 - `text` (string) - The message text (max 4096 characters)
 - `previewUrl` (boolean, optional) - Enable link preview for URLs in the message
 - `bizOpaqueCallbackData` (string, optional) - An arbitrary string for tracking
@@ -290,7 +341,8 @@ Sends an image message using a media ID obtained from the media upload endpoint.
 function sendImageMessage(params: {
   accessToken: string
   from: string
-  to: string
+  to?: string
+  recipient?: string
   mediaId: string
   caption?: string
   bizOpaqueCallbackData?: string
@@ -302,7 +354,8 @@ function sendImageMessage(params: {
 
 - `accessToken` (string) - Your WhatsApp Cloud API access token
 - `from` (string) - Your WhatsApp Phone Number ID
-- `to` (string) - Recipient's phone number with country code (e.g., "+16505551234")
+- `to` (string, optional) - Recipient's phone number with country code (e.g., "+16505551234"). At least one of `to` / `recipient` is required
+- `recipient` (string, optional) - Recipient's business-scoped user ID (BSUID). At least one of `to` / `recipient` is required; `to` takes precedence when both are set
 - `mediaId` (string) - The media ID obtained from `uploadMedia()`
 - `caption` (string, optional) - Optional caption for the image (max 1024 characters)
 - `bizOpaqueCallbackData` (string, optional) - An arbitrary string for tracking
@@ -380,7 +433,8 @@ Sends an interactive call-to-action URL button message to a WhatsApp user.
 function sendCTAURLMessage(params: {
   accessToken: string
   from: string
-  to: string
+  to?: string
+  recipient?: string
   bodyText: string
   buttonText: string
   url: string
@@ -396,7 +450,8 @@ function sendCTAURLMessage(params: {
 
 - `accessToken` (string) - Your WhatsApp Cloud API access token
 - `from` (string) - Your WhatsApp Phone Number ID
-- `to` (string) - Recipient's phone number with country code or phone number ID (e.g., "+16505551234" or "5551234")
+- `to` (string, optional) - Recipient's phone number with country code or phone number ID (e.g., "+16505551234" or "5551234"). At least one of `to` / `recipient` is required
+- `recipient` (string, optional) - Recipient's business-scoped user ID (BSUID). At least one of `to` / `recipient` is required; `to` takes precedence when both are set
 - `bodyText` (string) - Main message text. Maximum 1024 characters. URLs are automatically hyperlinked
 - `buttonText` (string) - Text displayed on the CTA button. Maximum 20 characters
 - `url` (string) - URL to open when button is tapped. Must start with `http://` or `https://` and cannot be an IP address
@@ -527,7 +582,8 @@ Sends a WhatsApp Flow message to guide users through interactive forms and exper
 function sendFlowMessage(params: {
   accessToken: string
   from: string
-  to: string
+  to?: string
+  recipient?: string
   bodyText: string
   flowToken: string
   flowId: string
@@ -549,7 +605,8 @@ function sendFlowMessage(params: {
 
 - `accessToken` (string) - Your WhatsApp Cloud API access token
 - `from` (string) - Your WhatsApp Phone Number ID
-- `to` (string) - Recipient's phone number with country code (e.g., "+16505551234")
+- `to` (string, optional) - Recipient's phone number with country code (e.g., "+16505551234"). At least one of `to` / `recipient` is required
+- `recipient` (string, optional) - Recipient's business-scoped user ID (BSUID). At least one of `to` / `recipient` is required; `to` takes precedence when both are set
 - `bodyText` (string) - Main message text. Maximum 1024 characters
 - `flowToken` (string) - Session token for the flow
 - `flowId` (string) - Unique ID of the flow
@@ -679,7 +736,8 @@ Sends an interactive message with reply buttons to a WhatsApp user.
 function sendButtonsMessage(params: {
   accessToken: string
   from: string
-  to: string
+  to?: string
+  recipient?: string
   bodyText: string
   buttons: { id: string; title: string }[]
   headerText?: string
@@ -696,7 +754,8 @@ function sendButtonsMessage(params: {
 
 - `accessToken` (string) - Your WhatsApp Cloud API access token
 - `from` (string) - Your WhatsApp Phone Number ID
-- `to` (string) - Recipient's phone number with country code (e.g., "+16505551234")
+- `to` (string, optional) - Recipient's phone number with country code (e.g., "+16505551234"). At least one of `to` / `recipient` is required
+- `recipient` (string, optional) - Recipient's business-scoped user ID (BSUID). At least one of `to` / `recipient` is required; `to` takes precedence when both are set
 - `bodyText` (string) - Main message text. Maximum 1024 characters
 - `buttons` (array) - Array of 1-3 button objects, each with:
   - `id` (string) - Unique button identifier. Maximum 256 characters
@@ -845,7 +904,8 @@ Sends an interactive message with a list of options to a WhatsApp user.
 function sendListMessage(params: {
   accessToken: string
   from: string
-  to: string
+  to?: string
+  recipient?: string
   bodyText: string
   buttonText: string
   sections: {
@@ -867,7 +927,8 @@ function sendListMessage(params: {
 
 - `accessToken` (string) - Your WhatsApp Cloud API access token
 - `from` (string) - Your WhatsApp Phone Number ID
-- `to` (string) - Recipient's phone number with country code (e.g., "+16505551234")
+- `to` (string, optional) - Recipient's phone number with country code (e.g., "+16505551234"). At least one of `to` / `recipient` is required
+- `recipient` (string, optional) - Recipient's business-scoped user ID (BSUID). At least one of `to` / `recipient` is required; `to` takes precedence when both are set
 - `bodyText` (string) - Main message text. Maximum 1024 characters
 - `buttonText` (string) - Text for the button that opens the list. Maximum 20 characters
 - `sections` (array) - Array of sections containing list items. Maximum 10 rows total across all sections, each with:

--- a/packages/client/src/sendButtonsMessage.test.ts
+++ b/packages/client/src/sendButtonsMessage.test.ts
@@ -610,3 +610,54 @@ it('accepts exactly 3 buttons', async () => {
 
   expect(mockSendRequest).toHaveBeenCalled()
 })
+
+it('sends a buttons message to a recipient (BSUID)', async () => {
+  const mockResponse = {
+    messaging_product: 'whatsapp' as const,
+    contacts: [{ input: 'US.123', wa_id: '1234567890' }],
+    messages: [{ id: 'wamid.123' }],
+  }
+
+  mockSendRequest.mockResolvedValueOnce(mockResponse)
+
+  await sendButtonsMessage({
+    accessToken: 'test_token',
+    from: '123456789',
+    recipient: 'US.123',
+    bodyText: 'Please select an option from the buttons below.',
+    buttons: [
+      { id: 'btn_1', title: 'Option 1' },
+      { id: 'btn_2', title: 'Option 2' },
+    ],
+  })
+
+  expect(mockSendRequest).toHaveBeenCalledWith(
+    'test_token',
+    '123456789',
+    {
+      messaging_product: 'whatsapp',
+      recipient_type: 'individual',
+      recipient: 'US.123',
+      type: 'interactive',
+      interactive: {
+        type: 'button',
+        body: {
+          text: 'Please select an option from the buttons below.',
+        },
+        action: {
+          buttons: [
+            {
+              type: 'reply',
+              reply: { id: 'btn_1', title: 'Option 1' },
+            },
+            {
+              type: 'reply',
+              reply: { id: 'btn_2', title: 'Option 2' },
+            },
+          ],
+        },
+      },
+    },
+    undefined,
+  )
+})

--- a/packages/client/src/sendButtonsMessage.ts
+++ b/packages/client/src/sendButtonsMessage.ts
@@ -12,6 +12,7 @@ import {
   InteractiveFooterMaxLength,
   InteractiveHeaderTextMaxLength,
 } from './constants.js'
+import { buildRecipient } from './internal/buildRecipient.js'
 import { sendRequest } from './internal/sendRequest.js'
 
 interface Button {
@@ -30,10 +31,16 @@ interface SendButtonsMessageParams {
   from: string
 
   /**
-   * The recipient's phone number with country code or phone number ID (e.g.
-   * "+16505551234" or "5551234")
+   * The recipient's phone number with country code or phone number ID
+   * (e.g. "+16505551234"). At least one of `to` / `recipient` is required.
    */
-  to: string
+  to?: string
+
+  /**
+   * The recipient's business-scoped user ID (BSUID).
+   * At least one of `to` / `recipient` is required; `to` takes precedence.
+   */
+  recipient?: string
 
   /** The main message text (maximum 1024 characters) */
   bodyText: string
@@ -87,6 +94,7 @@ export const sendButtonsMessage = async ({
   accessToken,
   from,
   to,
+  recipient,
   bodyText,
   buttons,
   headerText,
@@ -163,7 +171,7 @@ export const sendButtonsMessage = async ({
   const message: CloudAPISendInteractiveButtonsMessageRequest = {
     messaging_product: 'whatsapp',
     recipient_type: 'individual',
-    to,
+    ...buildRecipient(to, recipient),
     type: 'interactive',
     interactive: {
       type: 'button',

--- a/packages/client/src/sendCTAURLMessage.test.ts
+++ b/packages/client/src/sendCTAURLMessage.test.ts
@@ -500,3 +500,47 @@ it('accepts URLs with ports and paths', async () => {
     undefined,
   )
 })
+
+it('sends a CTA URL message to a recipient (BSUID)', async () => {
+  const mockResponse = {
+    messaging_product: 'whatsapp' as const,
+    contacts: [{ input: 'US.123', wa_id: '1234567890' }],
+    messages: [{ id: 'wamid.123' }],
+  }
+
+  mockSendRequest.mockResolvedValueOnce(mockResponse)
+
+  await sendCTAURLMessage({
+    accessToken: 'test_token',
+    from: '123456789',
+    recipient: 'US.123',
+    bodyText: 'Check out our latest deals.',
+    buttonText: 'Shop Now',
+    url: 'https://shop.example.com/deals',
+  })
+
+  expect(mockSendRequest).toHaveBeenCalledWith(
+    'test_token',
+    '123456789',
+    {
+      messaging_product: 'whatsapp',
+      recipient_type: 'individual',
+      recipient: 'US.123',
+      type: 'interactive',
+      interactive: {
+        type: 'cta_url',
+        body: {
+          text: 'Check out our latest deals.',
+        },
+        action: {
+          name: 'cta_url',
+          parameters: {
+            display_text: 'Shop Now',
+            url: 'https://shop.example.com/deals',
+          },
+        },
+      },
+    },
+    undefined,
+  )
+})

--- a/packages/client/src/sendCTAURLMessage.ts
+++ b/packages/client/src/sendCTAURLMessage.ts
@@ -8,6 +8,7 @@ import {
   InteractiveFooterMaxLength,
   InteractiveHeaderTextMaxLength,
 } from './constants.js'
+import { buildRecipient } from './internal/buildRecipient.js'
 import { sendRequest } from './internal/sendRequest.js'
 
 interface SendCTAURLMessageParams {
@@ -16,10 +17,15 @@ interface SendCTAURLMessageParams {
   /** The senders phone number ID (e.g. "1234567890") */
   from: string
   /**
-   * The recipient's phone number with country code or phone number ID (e.g.
-   * "+16505551234" or "5551234")
+   * The recipient's phone number with country code or phone number ID
+   * (e.g. "+16505551234"). At least one of `to` / `recipient` is required.
    */
-  to: string
+  to?: string
+  /**
+   * The recipient's business-scoped user ID (BSUID).
+   * At least one of `to` / `recipient` is required; `to` takes precedence.
+   */
+  recipient?: string
   /** The main message text (maximum 1024 characters) */
   bodyText: string
   /** The text displayed on the CTA button (maximum 20 characters) */
@@ -55,6 +61,7 @@ export const sendCTAURLMessage = async ({
   accessToken,
   from,
   to,
+  recipient,
   bodyText,
   buttonText,
   url,
@@ -122,7 +129,7 @@ export const sendCTAURLMessage = async ({
   const message: CloudAPISendInteractiveCTAURLRequest = {
     messaging_product: 'whatsapp',
     recipient_type: 'individual',
-    to,
+    ...buildRecipient(to, recipient),
     type: 'interactive',
     interactive: {
       type: 'cta_url',

--- a/packages/client/src/sendFlowMessage.test.ts
+++ b/packages/client/src/sendFlowMessage.test.ts
@@ -678,3 +678,56 @@ it('sends flow message with both screen and data in payload', async () => {
     undefined,
   )
 })
+
+it('sends a flow message to a recipient (BSUID)', async () => {
+  const mockResponse = {
+    messaging_product: 'whatsapp' as const,
+    contacts: [{ input: 'US.123', wa_id: '1234567890' }],
+    messages: [{ id: 'wamid.123' }],
+  }
+
+  mockSendRequest.mockResolvedValueOnce(mockResponse)
+
+  await sendFlowMessage({
+    accessToken: 'test_token',
+    from: '123456789',
+    recipient: 'US.123',
+    bodyText: 'Complete your application form to get started.',
+    flowToken: 'FLOW_TOKEN_123',
+    flowId: 'FLOW_ID_456',
+    flowCta: 'Start',
+    flowAction: 'navigate',
+    screen: 'welcome_screen',
+  })
+
+  expect(mockSendRequest).toHaveBeenCalledWith(
+    'test_token',
+    '123456789',
+    {
+      messaging_product: 'whatsapp',
+      recipient_type: 'individual',
+      recipient: 'US.123',
+      type: 'interactive',
+      interactive: {
+        type: 'flow',
+        body: {
+          text: 'Complete your application form to get started.',
+        },
+        action: {
+          name: 'flow',
+          parameters: {
+            flow_message_version: WhatsAppFlowMessageVersion,
+            flow_token: 'FLOW_TOKEN_123',
+            flow_id: 'FLOW_ID_456',
+            flow_cta: 'Start',
+            flow_action: 'navigate',
+            flow_action_payload: {
+              screen: 'welcome_screen',
+            },
+          },
+        },
+      },
+    },
+    undefined,
+  )
+})

--- a/packages/client/src/sendFlowMessage.ts
+++ b/packages/client/src/sendFlowMessage.ts
@@ -9,6 +9,7 @@ import {
   InteractiveHeaderTextMaxLength,
   WhatsAppFlowMessageVersion,
 } from './constants.js'
+import { buildRecipient } from './internal/buildRecipient.js'
 import { sendRequest } from './internal/sendRequest.js'
 
 interface SendFlowMessageParams {
@@ -17,10 +18,15 @@ interface SendFlowMessageParams {
   /** The senders phone number ID (e.g. "1234567890") */
   from: string
   /**
-   * The recipient's phone number with country code or phone number ID (e.g.
-   * "+16505551234" or "5551234")
+   * The recipient's phone number with country code or phone number ID
+   * (e.g. "+16505551234"). At least one of `to` / `recipient` is required.
    */
-  to: string
+  to?: string
+  /**
+   * The recipient's business-scoped user ID (BSUID).
+   * At least one of `to` / `recipient` is required; `to` takes precedence.
+   */
+  recipient?: string
   /** The main message text (maximum 1024 characters) */
   bodyText: string
   /** Token for flow session */
@@ -72,6 +78,7 @@ export const sendFlowMessage = async ({
   accessToken,
   from,
   to,
+  recipient,
   bodyText,
   flowToken,
   flowId,
@@ -128,7 +135,7 @@ export const sendFlowMessage = async ({
   const message: CloudAPISendFlowMessageRequest = {
     messaging_product: 'whatsapp',
     recipient_type: 'individual',
-    to,
+    ...buildRecipient(to, recipient),
     type: 'interactive',
     interactive: {
       type: 'flow',

--- a/packages/client/src/sendListMessage.test.ts
+++ b/packages/client/src/sendListMessage.test.ts
@@ -516,3 +516,54 @@ it('accepts exact character limits for all text fields', async () => {
 
   expect(mockSendRequest).toHaveBeenCalled()
 })
+
+it('sends a list message to a recipient (BSUID)', async () => {
+  const mockResponse = {
+    messaging_product: 'whatsapp' as const,
+    contacts: [{ input: 'US.123', wa_id: '1234567890' }],
+    messages: [{ id: 'wamid.123' }],
+  }
+
+  mockSendRequest.mockResolvedValueOnce(mockResponse)
+
+  await sendListMessage({
+    accessToken: 'test_token',
+    from: '123456789',
+    recipient: 'US.123',
+    bodyText: 'Please select a product category.',
+    buttonText: 'View Options',
+    sections: [
+      {
+        title: 'Electronics',
+        rows: [{ id: 'phone', title: 'Phones' }],
+      },
+    ],
+  })
+
+  expect(mockSendRequest).toHaveBeenCalledWith(
+    'test_token',
+    '123456789',
+    {
+      messaging_product: 'whatsapp',
+      recipient_type: 'individual',
+      recipient: 'US.123',
+      type: 'interactive',
+      interactive: {
+        type: 'list',
+        body: {
+          text: 'Please select a product category.',
+        },
+        action: {
+          button: 'View Options',
+          sections: [
+            {
+              title: 'Electronics',
+              rows: [{ id: 'phone', title: 'Phones' }],
+            },
+          ],
+        },
+      },
+    },
+    undefined,
+  )
+})

--- a/packages/client/src/sendListMessage.ts
+++ b/packages/client/src/sendListMessage.ts
@@ -16,6 +16,7 @@ import {
   ListSectionsMinCount,
   ListSectionTitleMaxLength,
 } from './constants.js'
+import { buildRecipient } from './internal/buildRecipient.js'
 import { sendRequest } from './internal/sendRequest.js'
 
 interface SendListMessageParams {
@@ -26,10 +27,16 @@ interface SendListMessageParams {
   from: string
 
   /**
-   * The recipient's phone number with country code or phone number ID (e.g.
-   * "+16505551234" or "5551234")
+   * The recipient's phone number with country code or phone number ID
+   * (e.g. "+16505551234"). At least one of `to` / `recipient` is required.
    */
-  to: string
+  to?: string
+
+  /**
+   * The recipient's business-scoped user ID (BSUID).
+   * At least one of `to` / `recipient` is required; `to` takes precedence.
+   */
+  recipient?: string
 
   /** The main message text (maximum 1024 characters) */
   bodyText: string
@@ -66,6 +73,7 @@ export const sendListMessage = async ({
   accessToken,
   from,
   to,
+  recipient,
   bodyText,
   buttonText,
   sections,
@@ -164,7 +172,7 @@ export const sendListMessage = async ({
   const message: CloudAPISendInteractiveListMessageRequest = {
     messaging_product: 'whatsapp',
     recipient_type: 'individual',
-    to,
+    ...buildRecipient(to, recipient),
     type: 'interactive',
     interactive: {
       type: 'list',

--- a/packages/client/src/sendTemplateMessage.test.ts
+++ b/packages/client/src/sendTemplateMessage.test.ts
@@ -360,3 +360,39 @@ it('sends a template message with button component', async () => {
     undefined,
   )
 })
+
+it('sends a template message to a recipient (BSUID)', async () => {
+  const mockResponse = {
+    messaging_product: 'whatsapp' as const,
+    contacts: [{ input: 'US.123', wa_id: '1234567890' }],
+    messages: [{ id: 'wamid.123' }],
+  }
+
+  mockSendRequest.mockResolvedValueOnce(mockResponse)
+
+  await sendTemplateMessage({
+    accessToken: 'test_token',
+    from: '123456789',
+    recipient: 'US.123',
+    templateName: 'hello_world',
+    languageCode: 'en_US',
+  })
+
+  expect(mockSendRequest).toHaveBeenCalledWith(
+    'test_token',
+    '123456789',
+    {
+      messaging_product: 'whatsapp',
+      recipient_type: 'individual',
+      recipient: 'US.123',
+      type: 'template',
+      template: {
+        name: 'hello_world',
+        language: {
+          code: 'en_US',
+        },
+      },
+    },
+    undefined,
+  )
+})

--- a/packages/client/src/sendTemplateMessage.ts
+++ b/packages/client/src/sendTemplateMessage.ts
@@ -3,6 +3,7 @@ import {
   CloudAPISendTemplateMessageRequest,
   CloudAPITemplateComponent,
 } from '@whatsapp-cloudapi/types/cloudapi'
+import { buildRecipient } from './internal/buildRecipient.js'
 import { sendRequest } from './internal/sendRequest.js'
 
 interface SendTemplateMessageParams {
@@ -11,10 +12,16 @@ interface SendTemplateMessageParams {
   /** The senders phone number ID (e.g. "1234567890") */
   from: string
   /**
-   * The recipient's phone number with country code or phone number ID (e.g.
-   * "+16505551234" or "5551234")
+   * The recipient's phone number with country code or phone number ID
+   * (e.g. "+16505551234"). At least one of `to` / `recipient` is required.
    */
-  to: string
+  to?: string
+  /**
+   * The recipient's business-scoped user ID (BSUID). Not supported for
+   * one-tap / zero-tap / copy-code authentication templates.
+   * At least one of `to` / `recipient` is required; `to` takes precedence.
+   */
+  recipient?: string
   /**
    * The name of the template to send
    * This must be an approved template name
@@ -159,6 +166,7 @@ export const sendTemplateMessage = async ({
   accessToken,
   from,
   to,
+  recipient,
   templateName,
   languageCode,
   languagePolicy,
@@ -170,7 +178,7 @@ export const sendTemplateMessage = async ({
   const message: CloudAPISendTemplateMessageRequest = {
     messaging_product: 'whatsapp',
     recipient_type: 'individual',
-    to,
+    ...buildRecipient(to, recipient),
     type: 'template',
     template: {
       name: templateName,

--- a/packages/client/src/sendTextMessage.test.ts
+++ b/packages/client/src/sendTextMessage.test.ts
@@ -171,3 +171,35 @@ it('throws an error when API request fails', async () => {
     }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: API Error]`)
 })
+
+it('sends a text message to a recipient (BSUID)', async () => {
+  const mockResponse = {
+    messaging_product: 'whatsapp' as const,
+    contacts: [{ input: 'US.123', wa_id: '1234567890' }],
+    messages: [{ id: 'wamid.123' }],
+  }
+
+  mockSendRequest.mockResolvedValueOnce(mockResponse)
+
+  await sendTextMessage({
+    accessToken: 'test_token',
+    from: '123456789',
+    recipient: 'US.123',
+    text: 'Hello World',
+  })
+
+  expect(mockSendRequest).toHaveBeenCalledWith(
+    'test_token',
+    '123456789',
+    {
+      messaging_product: 'whatsapp',
+      recipient_type: 'individual',
+      recipient: 'US.123',
+      type: 'text',
+      text: {
+        body: 'Hello World',
+      },
+    },
+    undefined,
+  )
+})

--- a/packages/client/src/sendTextMessage.ts
+++ b/packages/client/src/sendTextMessage.ts
@@ -2,6 +2,7 @@ import {
   CloudAPIResponse,
   CloudAPISendTextMessageRequest,
 } from '@whatsapp-cloudapi/types/cloudapi'
+import { buildRecipient } from './internal/buildRecipient.js'
 import { sendRequest } from './internal/sendRequest.js'
 
 interface SendTextMessageParams {
@@ -11,9 +12,14 @@ interface SendTextMessageParams {
   from: string
   /**
    * The recipient's phone number with country code or phone number ID
-   * (e.g. "+16505551234" or "5551234")
+   * (e.g. "+16505551234"). At least one of `to` / `recipient` is required.
    */
-  to: string
+  to?: string
+  /**
+   * The recipient's business-scoped user ID (BSUID).
+   * At least one of `to` / `recipient` is required; `to` takes precedence.
+   */
+  recipient?: string
   /** The text message to send */
   text: string
   /** Whether to enable link preview for URLs in the message */
@@ -33,6 +39,7 @@ export const sendTextMessage = async ({
   accessToken,
   from,
   to,
+  recipient,
   text,
   previewUrl,
   bizOpaqueCallbackData,
@@ -41,7 +48,7 @@ export const sendTextMessage = async ({
   const message: CloudAPISendTextMessageRequest = {
     messaging_product: 'whatsapp',
     recipient_type: 'individual',
-    to,
+    ...buildRecipient(to, recipient),
     type: 'text',
     text: {
       body: text,


### PR DESCRIPTION
## Summary

The v25.0 release ([#49](https://github.com/ericvera/whatsapp-cloudapi/pull/49)) added the new `recipient` parameter (business-scoped user ID, aka BSUID) as an alternative to `to` (phone number) across the send methods. The underlying request types already expose it via `CloudAPIRecipientAddressing`, and 13 of the 19 `send*Message` methods adopted it through the shared `buildRecipient()` helper.

**Six were missed**, leaving them addressable only by phone number:

- `sendTextMessage`
- `sendButtonsMessage`
- `sendCTAURLMessage`
- `sendListMessage`
- `sendFlowMessage`
- `sendTemplateMessage`

These six had `to: string` (required) and no `recipient` parameter, so callers had no way to send to a BSUID even though the wire format supports it.

## Changes

For each of the six methods (mirroring the existing `sendImageMessage` pattern):

- Make `to` optional (`to?: string`).
- Add `recipient?: string` (BSUID).
- Route addressing through `buildRecipient(to, recipient)`, which enforces "at least one of `to`/`recipient`" and gives `to` precedence when both are set.

The `sendTemplateMessage` JSDoc additionally notes that BSUID is not supported for one-tap/zero-tap/copy-code authentication templates (consistent with the type-level documentation on `CloudAPIMessageRequestBase.recipient`).

## Test plan

Added via TDD — failing-test commit first (`7c3b8f2`), then the fix (`9929f73`).

- [x] A new "sends to a recipient (BSUID)" Vitest case was added to each of the six co-located `*.test.ts` files. Each calls the method with `recipient: 'US.123'` (no `to`) and asserts `sendRequest` is invoked with `{ recipient: 'US.123', ... }` and no `to` field in the message body.
- [x] Tests were confirmed to fail against the unfixed code (the `recipient` arg was silently dropped and `to: undefined` appeared in the request body).
- [x] After the fix, all 6 newly added tests pass.
- [x] `yarn smoke` is green: 246/246 tests pass across all packages, plus `yarn build` (tsc) and `yarn lint`.

## Notes

- No changes to the `@whatsapp-cloudapi/types` package — the request types were already correct.
- No behavioral change for existing callers that pass `to` only.
- Conventional Commits: this lands as a `fix:` (not a breaking change) — `to` becomes optional, but every existing call site that supplied `to` continues to typecheck and behave identically.